### PR TITLE
More Mongoid5 changes - fixes #3 & #4

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -88,7 +88,7 @@ class Classification
     if self.task_key == "flag_bad_subject_task"
       subject.increment_flagged_bad_count_by_one
       # Push user_id onto Subject.deleting_user_ids if appropriate
-      Subject.where({id: subject.id}).find_and_modify({"$addToSet" => {deleting_user_ids: user_id.to_s}})
+      Subject.where({id: subject.id}).find_one_and_update({"$addToSet" => {deleting_user_ids: user_id.to_s}})
     end
 
     if self.task_key == "flag_illegible_subject_task"
@@ -96,7 +96,7 @@ class Classification
     end
     # subject.inc classification_count: 1
     # Push user_id onto Subject.user_ids using mongo's fast addToSet feature, which ensures uniqueness
-    subject_returned = Subject.where({id: subject_id}).find_and_modify({"$addToSet" => {classifying_user_ids: user_id.to_s}, "$inc" => {classification_count: 1}}, new: true)
+    subject_returned = Subject.where({id: subject_id}).find_one_and_update({"$addToSet" => {classifying_user_ids: user_id.to_s}, "$inc" => {classification_count: 1}}, new: true)
     
     #Passing the returned subject as parameters so that we eval the correct classification_count
     check_for_retirement_by_classification_count(subject_returned)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,6 +95,9 @@ API::Application.configure do
   # Enable the logstasher logs for the current environment
   config.logstasher.enabled = true
 
+  # Mongo default logger level is DEBUG (!), make it less verbose
+  Mongo::Logger.logger.level = Logger::WARN
+
   # React:
   config.react.variant = :production
   config.react.addons = true

--- a/lib/tasks/project.rake
+++ b/lib/tasks/project.rake
@@ -345,7 +345,7 @@ namespace :project do
     # Create a bunch of project-specific indexes:
     project = Project.current
 
-    SubjectSet.collection.dropIndexes
+    SubjectSet.remove_indexes
 
     # Create workflow counts indexes:
     project.workflows.each do |w|


### PR DESCRIPTION
These commits should hopefully fix #3 & #4 as reported by @justincy as well a make the production logger less verbose which is warned about in another set of migration notes.

@benwbrum please review
